### PR TITLE
Fix autogen, conflict between accounts and trim code. 

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,15 +20,15 @@ type ZoneConfig struct {
 	ActionSet map[string]struct{} `yaml:",omitempty"`
 }
 type AccountConfig struct {
-	ID            string           `yaml:"id"`
-	ZoneConfigs         []ZoneConfig `yaml:"zones"`
-	Token         string           `yaml:"token"`
-	IPListPrefix  string           `yaml:"ip_list_prefix"`
-	DefaultAction string           `yaml:"default_action"`
+	ID            string       `yaml:"id"`
+	ZoneConfigs   []ZoneConfig `yaml:"zones"`
+	Token         string       `yaml:"token"`
+	IPListPrefix  string       `yaml:"ip_list_prefix"`
+	DefaultAction string       `yaml:"default_action"`
 }
 type CloudflareConfig struct {
 	Accounts        []AccountConfig `yaml:"accounts"`
-	UpdateFrequency time.Duration       `yaml:"update_frequency"`
+	UpdateFrequency time.Duration   `yaml:"update_frequency"`
 }
 
 type bouncerConfig struct {
@@ -151,10 +151,11 @@ func ConfigTokens(tokens string, baseConfigPath string) (string, error) {
 		}
 		for i, account := range accounts {
 			accountConfig = append(accountConfig, AccountConfig{
-				ID:           account.ID,
-				ZoneConfigs:        make([]ZoneConfig, 0),
-				Token:        token,
-				IPListPrefix: "crowdsec",
+				ID:            account.ID,
+				ZoneConfigs:   make([]ZoneConfig, 0),
+				Token:         token,
+				IPListPrefix:  "crowdsec",
+				DefaultAction: "challenge",
 			})
 
 			api.AccountID = account.ID

--- a/main.go
+++ b/main.go
@@ -237,7 +237,6 @@ func main() {
 	var stateTomb tomb.Tomb
 
 	dispatchTomb.Go(func() error {
-		wg.Wait()
 		go csLapi.Run()
 		for {
 			decisions := <-csLapi.Stream

--- a/main.go
+++ b/main.go
@@ -49,21 +49,17 @@ func loadCachedStates(states *[]CloudflareState) error {
 		log.Debug("no cache found")
 		return nil
 	}
-
 	f, err := os.Open(cachePath)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
-	if err != nil {
-		return err
-	}
 	data, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}
-	json.Unmarshal(data, &states)
-	return nil
+	err = json.Unmarshal(data, &states)
+	return err
 }
 
 func dumpStates(states *[]CloudflareState) error {
@@ -123,10 +119,6 @@ func main() {
 	if configPath == nil || *configPath == "" {
 		*configPath = DEFAULT_CONFIG_PATH
 	}
-	conf, err := NewConfig(*configPath)
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	if configTokens != nil && *configTokens != "" {
 		cfg, err := ConfigTokens(*configTokens, *configPath)
@@ -136,12 +128,12 @@ func main() {
 		fmt.Print(cfg)
 		return
 	}
-
-	ctx := context.Background()
+	conf, err := NewConfig(*configPath)
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	ctx := context.Background()
 	csLapi := &csbouncer.StreamBouncer{
 		APIKey:         conf.CrowdSecLAPIKey,
 		APIUrl:         conf.CrowdSecLAPIUrl,


### PR DESCRIPTION
Autogen : Don't lint the base config when generating config. This was causing the error about missing account id.

Conflict between account workers : Two workers having access to some common zone, would try to delete and create the same rule at same time. This is fixed by a waitgroup. All workers wait for each other till the cleanup process and then together move on  to  create rules. 

Trim Code : The `Run` method of worker is shortened via magic of first class functions

