### PR TITLE
Enforce rate limit per token

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cloudflare/cloudflare-go"
@@ -14,6 +15,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 )
+
+const CallsPerSecondLimit uint32 = 4
 
 var CloudflareActionByDecisionType = map[string]string{
 	"captcha":      "challenge",
@@ -116,6 +119,7 @@ type CloudflareWorker struct {
 	API                     cloudflareAPI
 	Wg                      *sync.WaitGroup
 	Count                   prometheus.Counter
+	tokenCallCount          *uint32
 }
 
 type cloudflareAPI interface {
@@ -200,6 +204,10 @@ func (worker *CloudflareWorker) getMutexByZoneID(zoneID string) (*sync.Mutex, er
 }
 
 func (worker *CloudflareWorker) getAPI() cloudflareAPI {
+	atomic.AddUint32(worker.tokenCallCount, 1)
+	if *worker.tokenCallCount > CallsPerSecondLimit {
+		time.Sleep(time.Second)
+	}
 	worker.Count.Inc()
 	return worker.API
 }
@@ -508,10 +516,7 @@ func (worker *CloudflareWorker) Init() error {
 	if worker.API == nil { // this for easy swapping during tests
 		worker.API, err = cloudflare.NewWithAPIToken(worker.Account.Token, cloudflare.UsingAccount(worker.Account.ID))
 	}
-	if err != nil {
-		worker.Logger.Error(err.Error())
-		return err
-	}
+
 	worker.Logger.Debug("setup of API complete")
 
 	if len(worker.CFStateByAction) != 0 {
@@ -762,7 +767,6 @@ func (worker *CloudflareWorker) Run() error {
 		case decisions := <-worker.LAPIStream:
 			worker.Logger.Debug("collecting decisions from LAPI")
 			worker.CollectLAPIStream(decisions)
-
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -309,7 +309,6 @@ func main() {
 	for {
 		select {
 		case <-workerTomb.Dying():
-			fmt.Println("HEREE !!!! ")
 			dispatchTomb.Kill(nil)
 			err := workerTomb.Err()
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -10,7 +10,9 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"sync/atomic"
 	"syscall"
+	"time"
 
 	"github.com/coreos/go-systemd/daemon"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
@@ -162,6 +164,7 @@ func main() {
 	lapiStreams := make([]chan *models.DecisionsStreamResponse, 0)
 	stateStream := make(chan map[string]*CloudflareState)
 	workerStates := make([]CloudflareState, 0)
+	APICountByToken := make(map[string]*uint32)
 
 	err = loadCachedStates(&workerStates)
 	if err != nil {
@@ -179,6 +182,10 @@ func main() {
 				states[s.Action] = &tmp
 			}
 		}
+		var tokenCallCount uint32 = 0
+		if _, ok := APICountByToken[account.Token]; !ok {
+			APICountByToken[account.Token] = &tokenCallCount
+		}
 
 		wg.Add(1)
 		worker := CloudflareWorker{
@@ -191,6 +198,7 @@ func main() {
 			UpdatedState:    stateStream,
 			CFStateByAction: states,
 			Count:           Count,
+			tokenCallCount:  APICountByToken[account.Token],
 		}
 		if *onlySetup {
 			workerTomb.Go(func() error {
@@ -288,9 +296,20 @@ func main() {
 		go HandleSignals()
 	}
 
+	apiCallCounterWindow := time.NewTicker(time.Second)
+	go func() {
+		for {
+			<-apiCallCounterWindow.C
+			for token := range APICountByToken {
+				atomic.SwapUint32(APICountByToken[token], 0)
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-workerTomb.Dying():
+			fmt.Println("HEREE !!!! ")
 			dispatchTomb.Kill(nil)
 			err := workerTomb.Err()
 			if err != nil {


### PR DESCRIPTION
1. Create counter per token.
2. Increment the counter per api call, if it exceeds the rate limit of 4 req per second, delay. 
3. Every one 1 second reset counter. 