### PR TITLE
added trimpath to build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ BUILD_TAG="$(shell git rev-parse HEAD)"
 export LD_OPTS=-ldflags "-s -w -X github.com/crowdsecurity/cs-cloudflare-bouncer/version.Version=$(BUILD_VERSION) \
 -X github.com/crowdsecurity/cs-cloudflare-bouncer/version.BuildDate=$(BUILD_TIMESTAMP) \
 -X github.com/crowdsecurity/cs-cloudflare-bouncer/version.Tag=$(BUILD_TAG) \
--X github.com/crowdsecurity/cs-cloudflare-bouncer/version.GoVersion=$(BUILD_GOVERSION)"
+-X github.com/crowdsecurity/cs-cloudflare-bouncer/version.GoVersion=$(BUILD_GOVERSION)" \
+-trimpath
 PREFIX?="/"
 PID_DIR = $(PREFIX)"/var/run/"
 BINARY_NAME=crowdsec-cloudflare-bouncer


### PR DESCRIPTION
After experiencing #83 it took me longer than expected to find the repo (go to docs → bouncer → notice that the readme doesn't lead to the repo → go to main repo → go to orga → go to cloudflare bouncer)

after applying this patch, stack traces will change:

old:
```
main.(*CloudflareWorker).UpdateIPLists(0xc00015d080)
        /codebuild/output/src245/src/s3/01/cloudflare.go:451 +0x2fb
main.(*CloudflareWorker).runProcessorOnDecisions(0xc00015d080, 0xc0009cdf10, {0xc00074e000, 0x0, 0x438820})
        /codebuild/output/src245/src/s3/01/cloudflare.go:915 +0xb2
main.(*CloudflareWorker).Run(0xc00015d080)
        /codebuild/output/src245/src/s3/01/cloudflare.go:940 +0x377
```

new:
```
main.(*CloudflareWorker).UpdateIPLists(0xc00015d080)
        github.com/crowdsecurity/cs-cloudflare-bouncer/cloudflare.go:451 +0x2fb
main.(*CloudflareWorker).runProcessorOnDecisions(0xc00015d080, 0xc0009cdf10, {0xc00074e000, 0x0, 0x438820})
        github.com/crowdsecurity/cs-cloudflare-bouncer/cloudflare.go:915 +0xb2
main.(*CloudflareWorker).Run(0xc00015d080)
        github.com/crowdsecurity/cs-cloudflare-bouncer/cloudflare.go:940 +0x377
```

This way it's immediately obvious where to find the project